### PR TITLE
DOP-3100: Add formatting and linting to the backend

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -37,12 +37,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10.x'
-      - name: Install pipenv
+      - name: Install pipenv and dependencies
         run: |
           pip install pipenv
+          pipenv install --dev
+      - name: Format and lint backend
+        run: pipenv run format && pipenv run lint
       - name: Run tests
         run: |
-          pipenv install --dev
           pipenv run test
 
   frontend:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           pip install pipenv
           pipenv install --dev
-      - name: Format and lint backend
+      - name: Format and lint
         run: pipenv run format && pipenv run lint
       - name: Run tests
         run: |
@@ -63,9 +63,9 @@ jobs:
           node-version: '16.x'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
-      - name: Install frontend dependencies
+      - name: Install dependencies
         run: npm ci
-      - name: Lint Frontend
-        run: npm run lint && npm run format
-      - name: Test Frontend
+      - name: Format and lint
+        run: npm run format && npm run lint
+      - name: Run tests
         run: npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-cd frontend
-npm run lint-frontend
-
-# TODO: we can invoke backend linting here
-# See example: https://stackoverflow.com/questions/64001471/pylint-with-pre-commit-and-esllint-with-husky

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 22.6.0
+  hooks:
+  - id: black
+    name: Format backend
+    files: ^backend/.*\.py
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
+    name: Lint backend
+    entry: flake8
+    language: python
+    files: '^backend/.*\.py'
+# Calls lint-frontend command in place of husky
+- repo: local
+  hooks:
+  - id: frontend-pre-commit
+    name: Lint and format frontend
+    language: system
+    entry: npm --prefix ./frontend run lint-frontend
+    pass_filenames: false
+    always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,8 @@ repos:
     entry: flake8
     language: python
     files: '^backend/.*\.py'
-# Calls lint-frontend command in place of husky
+# Use local command for linting instead of eslint mirror for convenient usage of 
+# configuration file (.eslintrc.json)
 - repo: local
   hooks:
   - id: frontend-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,6 @@ repos:
     name: Lint and format frontend
     language: system
     entry: npm --prefix ./frontend run lint-frontend
+    # lint-staged has its own set of files to process
     pass_filenames: false
-    always_run: true
+    verbose: true

--- a/README.md
+++ b/README.md
@@ -30,3 +30,25 @@ Hapley is deployed on the Kanopy platform. A merge into `main` triggers the Dron
 ### Production Release
 
 TBD. Need to determine production release workflow once we've finished application development. Perhaps take inspiration from the [Dev Center setup](https://github.com/mongodb/devcenter#production-release).
+## Development
+
+### Pre-commit hooks
+
+This monorepo uses [pre-commit](https://github.com/pre-commit/pre-commit) to 
+help lint and format both backend and frontend files before they are committed 
+through git.
+
+With python 3.10, install and set up `pre-commit` for this repo by doing the 
+following:
+
+```
+pip install pre-commit
+pre-commit install
+```
+
+This will allow `pre-commit` to be run when doing `git commit`. To test pre-commit 
+hooks locally, run:
+
+```
+pre-commit run
+```

--- a/README.md
+++ b/README.md
@@ -16,23 +16,7 @@ To read more about the application backend, see the [README](./backend/README.md
 
 ## Development and Deployment Workflow
 
-Create a new branch off of `main` with your changes for a given feature or bug fix. Please include the JIRA ticket within the branch name. For example, `dop-1234-test`.
-
-When you are ready to contribute your changes, open a pull request against `main` with the ticket name in the title. You should also link to the Jira ticket within the pull request description. Once a PR is opened, tests will be run via GitHub Actions. You can read more about the linting and testing tools we use in the READMEs for `backend` and `frontend`. All PRs must pass the pull request checks prior to merging. Additionally, you must receive at least one PR approval prior to merging. Pull requests gets squashed into a single commit upon merging into `main`.
-
-### Staging Release 
-
-Hapley is deployed on the Kanopy platform. A merge into `main` triggers the Drone pipelines setup in `.drone.yml`. Once the build is completed, it is promoted to staging automatically.
-
-- Backend staging link: https://hapley.docs.staging.corp.mongodb.com/api/v1
-- Frontend staging link: https://hapley.docs.staging.corp.mongodb.com/
-
-### Production Release
-
-TBD. Need to determine production release workflow once we've finished application development. Perhaps take inspiration from the [Dev Center setup](https://github.com/mongodb/devcenter#production-release).
-## Development
-
-### Pre-commit hooks
+### Pre-commit Hooks
 
 This monorepo uses [pre-commit](https://github.com/pre-commit/pre-commit) to 
 help lint and format both backend and frontend files before they are committed 
@@ -52,3 +36,20 @@ hooks locally, run:
 ```
 pre-commit run
 ```
+
+### Pull Requests
+
+Create a new branch off of `main` with your changes for a given feature or bug fix. Please include the JIRA ticket within the branch name. For example, `dop-1234-test`.
+
+When you are ready to contribute your changes, open a pull request against `main` with the ticket name in the title. You should also link to the Jira ticket within the pull request description. Once a PR is opened, tests will be run via GitHub Actions. You can read more about the linting and testing tools we use in the READMEs for `backend` and `frontend`. All PRs must pass the pull request checks prior to merging. Additionally, you must receive at least one PR approval prior to merging. Pull requests gets squashed into a single commit upon merging into `main`.
+
+### Staging Release 
+
+Hapley is deployed on the Kanopy platform. A merge into `main` triggers the Drone pipelines setup in `.drone.yml`. Once the build is completed, it is promoted to staging automatically.
+
+- Backend staging link: https://hapley.docs.staging.corp.mongodb.com/api/v1
+- Frontend staging link: https://hapley.docs.staging.corp.mongodb.com/
+
+### Production Release
+
+TBD. Need to determine production release workflow once we've finished application development. Perhaps take inspiration from the [Dev Center setup](https://github.com/mongodb/devcenter#production-release).

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -12,10 +12,14 @@ pydantic = "~=1.9.0"
 pytest = "~=7.1.0"
 pytest-cov = "~=3.0.0"
 requests = "~=2.28.0"
+flake8 = "~=4.0.0"
+black = "~=22.6.0"
 
 [requires]
 python_version = "3.10"
 
 [scripts]
 app = "uvicorn main:app --reload"
+format = "pipenv run black ."
+lint = "pipenv run flake8 ."
 test = "pipenv run pytest --cov=. tests/"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "eaeaae038518a6e07f7010e67943db991aba5073c407a1bfd664a298fcfa183d"
+            "sha256": "2931af3eea347e154fc809b2a62f5c8254041861c29453d078668e4b51f18cd8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -139,6 +139,35 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.4.0"
         },
+        "black": {
+            "hashes": [
+                "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90",
+                "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c",
+                "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78",
+                "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4",
+                "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee",
+                "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e",
+                "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e",
+                "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6",
+                "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9",
+                "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c",
+                "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256",
+                "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f",
+                "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2",
+                "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c",
+                "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b",
+                "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807",
+                "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf",
+                "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def",
+                "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad",
+                "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d",
+                "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849",
+                "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69",
+                "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"
+            ],
+            "index": "pypi",
+            "version": "==22.6.0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
@@ -154,6 +183,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.1.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
         },
         "coverage": {
             "extras": [
@@ -205,6 +242,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==6.4.1"
         },
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
         "idna": {
             "hashes": [
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
@@ -220,6 +265,20 @@
             ],
             "version": "==1.1.1"
         },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -227,6 +286,21 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==21.3"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.2"
         },
         "pluggy": {
             "hashes": [
@@ -243,6 +317,22 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.11.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
         },
         "pyparsing": {
             "hashes": [

--- a/backend/README.md
+++ b/backend/README.md
@@ -98,7 +98,14 @@ more information on usage.
 
 ## Linting and Styling
 
-To be added in future PR.
+The backend uses [black](https://black.readthedocs.io/en/stable/) for formatting 
+and [flake8](https://flake8.pycqa.org/en/latest/) for linting. Run the following 
+commands to format and lint locally.
+
+```
+pipenv run format
+pipenv run lint
+```
 
 ## FastAPI Resources
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,11 +8,11 @@ app = FastAPI()
 # Prevent CORS errors in local development
 origins = ["http://localhost:3000"]
 app.add_middleware(
-    CORSMiddleware, 
+    CORSMiddleware,
     allow_origins=origins,
-    allow_credentials=True, 
+    allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"]
+    allow_headers=["*"],
 )
 
 app.include_router(hello_world.router)

--- a/backend/routers/hello_world.py
+++ b/backend/routers/hello_world.py
@@ -5,4 +5,4 @@ router = APIRouter(prefix='/api/v1')
 
 @router.get("/hello")
 async def read_hello():
-  return {"message": "Hello World"}
+    return {"message": "Hello World"}

--- a/backend/routers/hello_world.py
+++ b/backend/routers/hello_world.py
@@ -5,4 +5,4 @@ router = APIRouter(prefix='/api/v1')
 
 @router.get("/hello")
 async def read_hello():
-    return {"message": "Hello World"}
+  return {"message": "Hello World"}

--- a/backend/routers/hello_world.py
+++ b/backend/routers/hello_world.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-router = APIRouter(prefix='/api/v1')
+router = APIRouter(prefix="/api/v1")
 
 
 @router.get("/hello")

--- a/backend/routers/hello_world.py
+++ b/backend/routers/hello_world.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 router = APIRouter(prefix='/api/v1')
 
+
 @router.get("/hello")
 async def read_hello():
-  return {"message": "Hello World"}
+    return {"message": "Hello World"}

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -1,2 +1,4 @@
 [flake8]
+# Ignore rules
+# E501 - max line length
 ignore = E501

--- a/backend/tests/routers/test_hello_world.py
+++ b/backend/tests/routers/test_hello_world.py
@@ -2,10 +2,9 @@ from ..base import FastApiTest
 
 client = FastApiTest()
 
-def test_hello_world():
-  response = client.get("/hello")
 
-  assert response.status_code == 200
-  assert response.json() == {
-    "message": "Hello World"
-  }
+def test_hello_world():
+    response = client.get("/hello")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello World"}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -16,5 +16,10 @@
   "plugins": ["react", "@typescript-eslint", "@emotion"],
   "rules": {
     "@emotion/pkg-renaming": "error"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,6 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "husky": "^8.0.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
@@ -13073,21 +13072,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -31201,12 +31185,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
-    },
-    "husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "develop": "gatsby develop -p 3000",
     "start": "gatsby develop -H 0.0.0.0 -p 3000",
     "build": "gatsby build",
-    "prepare": "cd ../ && husky install ./frontend/.husky",
     "serve": "gatsby serve -H 0.0.0.0 -p 3000",
     "clean": "gatsby clean",
     "test": "jest",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "husky": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",

--- a/frontend/src/components/HelloWorld.tsx
+++ b/frontend/src/components/HelloWorld.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 // Sample component that renders simple text.
 const HelloWorld: React.FC<{}> = () => (

--- a/frontend/src/components/HelloWorld.tsx
+++ b/frontend/src/components/HelloWorld.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 // Sample component that renders simple text.
 const HelloWorld: React.FC<{}> = () => (


### PR DESCRIPTION
### Ticket

DOP-3100

### Notes

* Uses `pre-commit` to run pre-commit hooks. See [this section](https://github.com/mongodb/docs-hapley/blob/8991c4638ac50c4ff5bb010d705697520a6b4ad3/README.md#pre-commit-hooks) on pre-commit hooks in the `README`. If you already had `husky` installed locally, you may need to run `git config --unset-all core.hooksPath` in your local repo before running `pre-commit install`.
* Removes `husky` as a dependency for the frontend. `pre-commit` already does the job of running pre-commit hooks.