### PR TITLE
DOP-3149: Account for auth token in cookies rather than Auth header, align Dockerfile with new project structure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,11 +8,10 @@ steps:
   - name: backend-test
     image: python:3.10-bullseye
     commands:
-    # - cd backend
-    # - pip install pipenv
-    # - pipenv install --dev
-    # - pipenv run test
-    - echo "hello world"
+    - cd backend
+    - pip install pipenv
+    - pipenv install --dev
+    - pipenv run test
     when:
       event:
         - push
@@ -20,7 +19,6 @@ steps:
 trigger:
   branch:
     - main
-    - dop-3149-dockerfile-fix
   event:
     - push
 
@@ -34,10 +32,9 @@ steps:
   - name: frontend-test
     image: node:16-alpine
     commands:
-    # - cd frontend
-    # - npm install
-    # - npm run test
-    - echo "hello world"
+    - cd frontend
+    - npm install
+    - npm run test
     when:
       event:
         - push
@@ -45,7 +42,6 @@ steps:
 trigger:
   branch:
     - main
-    - dop-3149-dockerfile-fix
   event:
     - push
 
@@ -56,30 +52,30 @@ type: kubernetes
 name: build-hapley-staging
 
 steps:
-  # - name: publish-staging-frontend-image
-  #   image: plugins/kaniko-ecr
-  #   environment:
-  #     GATSBY_API_URL: https://hapley.docs.staging.corp.mongodb.com/api/v1
-  #   settings:
-  #     create_repository: true
-  #     enable_cache: true
-  #     dockerfile: ./frontend/Dockerfile
-  #     context: ./frontend
-  #     registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
-  #     repo: docs/${DRONE_REPO_NAME}/frontend
-  #     build_args:
-  #       - GATSBY_API_URL
-  #     tags:
-  #     - ${DRONE_SOURCE_BRANCH}
-  #     - drone-build-${DRONE_BUILD_NUMBER}
-  #     - ${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
-  #     access_key:
-  #       from_secret: ecr_access_key
-  #     secret_key:
-  #       from_secret: ecr_secret_key
-  #   when:
-  #     event:
-  #     - push
+  - name: publish-staging-frontend-image
+    image: plugins/kaniko-ecr
+    environment:
+      GATSBY_API_URL: https://hapley.docs.staging.corp.mongodb.com/api/v1
+    settings:
+      create_repository: true
+      enable_cache: true
+      dockerfile: ./frontend/Dockerfile
+      context: ./frontend
+      registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
+      repo: docs/${DRONE_REPO_NAME}/frontend
+      build_args:
+        - GATSBY_API_URL
+      tags:
+      - ${DRONE_SOURCE_BRANCH}
+      - drone-build-${DRONE_BUILD_NUMBER}
+      - ${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
+      access_key:
+        from_secret: ecr_access_key
+      secret_key:
+        from_secret: ecr_secret_key
+    when:
+      event:
+      - push
     
   - name: publish-staging-backend-image
     image: plugins/kaniko-ecr
@@ -117,7 +113,6 @@ steps:
 trigger:
   branch:
     - main
-    - dop-3149-dockerfile-fix
   event:
     - push
 
@@ -128,19 +123,19 @@ type: kubernetes
 name: deploy-hapley-staging
 
 steps:
-  # - name: deploy-staging-frontend
-  #   image: quay.io/mongodb/drone-helm:v3
-  #   settings:
-  #     chart: mongodb/web-app
-  #     chart_version: 4.7.3
-  #     add_repos: [mongodb=https://10gen.github.io/helm-charts]
-  #     namespace: docs
-  #     release: hapley
-  #     values: image.tag=${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME}/frontend
-  #     values_files: ["environments/frontend-staging.yaml"]
-  #     api_server: https://api.staging.corp.mongodb.com
-  #     kubernetes_token:
-  #       from_secret: staging_kubernetes_token
+  - name: deploy-staging-frontend
+    image: quay.io/mongodb/drone-helm:v3
+    settings:
+      chart: mongodb/web-app
+      chart_version: 4.7.3
+      add_repos: [mongodb=https://10gen.github.io/helm-charts]
+      namespace: docs
+      release: hapley
+      values: image.tag=${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME}/frontend
+      values_files: ["environments/frontend-staging.yaml"]
+      api_server: https://api.staging.corp.mongodb.com
+      kubernetes_token:
+        from_secret: staging_kubernetes_token
   
   - name: deploy-staging-backend
     image: quay.io/mongodb/drone-helm:v3

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,10 +8,11 @@ steps:
   - name: backend-test
     image: python:3.10-bullseye
     commands:
-    - cd backend
-    - pip install pipenv
-    - pipenv install --dev
-    - pipenv run test
+    # - cd backend
+    # - pip install pipenv
+    # - pipenv install --dev
+    # - pipenv run test
+    - echo "hello world"
     when:
       event:
         - push
@@ -33,9 +34,10 @@ steps:
   - name: frontend-test
     image: node:16-alpine
     commands:
-    - cd frontend
-    - npm install
-    - npm run test
+    # - cd frontend
+    # - npm install
+    # - npm run test
+    - echo "hello world"
     when:
       event:
         - push
@@ -54,30 +56,30 @@ type: kubernetes
 name: build-hapley-staging
 
 steps:
-  - name: publish-staging-frontend-image
-    image: plugins/kaniko-ecr
-    environment:
-      GATSBY_API_URL: https://hapley.docs.staging.corp.mongodb.com/api/v1
-    settings:
-      create_repository: true
-      enable_cache: true
-      dockerfile: ./frontend/Dockerfile
-      context: ./frontend
-      registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
-      repo: docs/${DRONE_REPO_NAME}/frontend
-      build_args:
-        - GATSBY_API_URL
-      tags:
-      - ${DRONE_SOURCE_BRANCH}
-      - drone-build-${DRONE_BUILD_NUMBER}
-      - ${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
-      access_key:
-        from_secret: ecr_access_key
-      secret_key:
-        from_secret: ecr_secret_key
-    when:
-      event:
-      - push
+  # - name: publish-staging-frontend-image
+  #   image: plugins/kaniko-ecr
+  #   environment:
+  #     GATSBY_API_URL: https://hapley.docs.staging.corp.mongodb.com/api/v1
+  #   settings:
+  #     create_repository: true
+  #     enable_cache: true
+  #     dockerfile: ./frontend/Dockerfile
+  #     context: ./frontend
+  #     registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
+  #     repo: docs/${DRONE_REPO_NAME}/frontend
+  #     build_args:
+  #       - GATSBY_API_URL
+  #     tags:
+  #     - ${DRONE_SOURCE_BRANCH}
+  #     - drone-build-${DRONE_BUILD_NUMBER}
+  #     - ${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
+  #     access_key:
+  #       from_secret: ecr_access_key
+  #     secret_key:
+  #       from_secret: ecr_secret_key
+  #   when:
+  #     event:
+  #     - push
     
   - name: publish-staging-backend-image
     image: plugins/kaniko-ecr
@@ -126,19 +128,19 @@ type: kubernetes
 name: deploy-hapley-staging
 
 steps:
-  - name: deploy-staging-frontend
-    image: quay.io/mongodb/drone-helm:v3
-    settings:
-      chart: mongodb/web-app
-      chart_version: 4.7.3
-      add_repos: [mongodb=https://10gen.github.io/helm-charts]
-      namespace: docs
-      release: hapley
-      values: image.tag=${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME}/frontend
-      values_files: ["environments/frontend-staging.yaml"]
-      api_server: https://api.staging.corp.mongodb.com
-      kubernetes_token:
-        from_secret: staging_kubernetes_token
+  # - name: deploy-staging-frontend
+  #   image: quay.io/mongodb/drone-helm:v3
+  #   settings:
+  #     chart: mongodb/web-app
+  #     chart_version: 4.7.3
+  #     add_repos: [mongodb=https://10gen.github.io/helm-charts]
+  #     namespace: docs
+  #     release: hapley
+  #     values: image.tag=${DRONE_SOURCE_BRANCH}-${DRONE_COMMIT_SHA:0:7},image.repository=795250896452.dkr.ecr.us-east-1.amazonaws.com/docs/${DRONE_REPO_NAME}/frontend
+  #     values_files: ["environments/frontend-staging.yaml"]
+  #     api_server: https://api.staging.corp.mongodb.com
+  #     kubernetes_token:
+  #       from_secret: staging_kubernetes_token
   
   - name: deploy-staging-backend
     image: quay.io/mongodb/drone-helm:v3

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,7 @@ steps:
 trigger:
   branch:
     - main
+    - dop-3149-dockerfile-fix
   event:
     - push
 
@@ -42,6 +43,7 @@ steps:
 trigger:
   branch:
     - main
+    - dop-3149-dockerfile-fix
   event:
     - push
 
@@ -113,6 +115,7 @@ steps:
 trigger:
   branch:
     - main
+    - dop-3149-dockerfile-fix
   event:
     - push
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,5 +4,5 @@ COPY ["Pipfile", "Pipfile.lock", "./"]
 RUN pip install pipenv \
     && pipenv install --system
 COPY *.py ./
-COPY ./routers ./routers
+COPY ./api ./api
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -9,6 +9,7 @@ uvicorn = "~=0.18.0"
 pydantic = "~=1.9.0"
 python-jose = "~=3.3.0"
 beanie = "~=1.11.0"
+dnspython = "~=1.16.0"
 
 [dev-packages]
 pytest = "~=7.1.0"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fa9f673f8d1fbbc9f58b35ea16cc1eea8f49eb2af4df6d60940651f3f7049ab0"
+            "sha256": "09095321c9cdbc8d0db2863b1f769a750043c385d056b5f3d705193646384ab3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,6 +39,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
+        },
+        "dnspython": {
+            "hashes": [
+                "sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01",
+                "sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d"
+            ],
+            "index": "pypi",
+            "version": "==1.16.0"
         },
         "ecdsa": {
             "hashes": [
@@ -206,92 +214,75 @@
         },
         "pymongo": {
             "hashes": [
-                "sha256:019a4c13ef1d9accd08de70247068671b116a0383adcd684f6365219f29f41cd",
-                "sha256:07f50a3b8a3afb086089abcd9ab562fb2a27b63fd7017ca13dfe7b663c8f3762",
-                "sha256:08a619c92769bd7346434dfc331a3aa8dc63bee80ed0be250bb0e878c69a6f3e",
-                "sha256:0a3474e6a0df0077a44573727341df6627042df5ca61ea5373c157bb6512ccc7",
-                "sha256:0b8a1c766de29173ddbd316dbd75a97b19a4cf9ac45a39ad4f53426e5df1483b",
-                "sha256:0f7e3872fb7b61ec574b7e04302ea03928b670df583f8691cb1df6e54cd42b19",
-                "sha256:17df40753085ccba38a0e150001f757910d66440d9b5deced30ed4cc8b45b6f3",
-                "sha256:298908478d07871dbe17e9ccd37a10a27ad3f37cc1faaf0cc4d205da3c3e8539",
-                "sha256:302ac0f4825501ab0900b8f1a2bb2dc7d28f69c7f15fbc799fb26f9b9ebb1ecb",
-                "sha256:303d1b3da2461586379d98b344b529598c8156857285ba5bd156dab1c875d1f6",
-                "sha256:306336dab4537b2343e52ec34017c3051c3aee5a961fff4915ab27f7e6d9b1e9",
-                "sha256:30d35a8855f328a85e5002f0908b24e500efdf8f5f78b73098995ce111baa2a9",
-                "sha256:3139c9ddee379c22a9109a0b3bf4cdb64597db2bbd3909f7a2825b47226977a4",
-                "sha256:32e785c37f6a0e844788c6085ea2c9c0c528348c22cebe91896705a92f2b1b26",
-                "sha256:33a5693e8d1fbb7743b7e867d43c1095652a0c6fedddab6cefe6020bee2ca393",
-                "sha256:35d02603c2318676fca5049cdc722bb2e7a378eaccf139ad767365e0eb3bcdbe",
-                "sha256:4516a5ce2beaebddc74d6e304ed520324dda99573c310ef4078284b026f81e93",
-                "sha256:49bb36986f11da2da190a2e777a411c0a28eeb8623850091ea8099b84e3860c7",
-                "sha256:4aa4800530782f7d38aeb169476a5bc692aacc394686f0ca3866e4bb85c9aa3f",
-                "sha256:4d1cdece06156542c18b691511a01fe78a694b9fa287ffd8e15680dbf2beeed5",
-                "sha256:4e4d2babb8737d650250d0fa940ffa1b88aa92b8eb399af093734950a1eeca45",
-                "sha256:4fd5c4f25d8d488ee5701c3ec786f52907dca653b47ce8709bcc2bfb0f5506ae",
-                "sha256:52c8b7bffd2140818ade2aa28c24cfe47935a7273a3bb976d1d8fb17e716536f",
-                "sha256:56b856a459762a3c052987e28ed2bd4b874f0be6671d2cc4f74c4891f47f997a",
-                "sha256:571a3e1ef4abeb4ac719ac381f5aada664627b4ee048d9995e93b4bcd0f70601",
-                "sha256:5cae9c935cdc53e4729920543b7d990615a115d85f32144773bc4b2b05144628",
-                "sha256:5d6ef3fa41f3e3be93483a77f81dea8c7ce5ed4411382a31af2b09b9ec5d9585",
-                "sha256:6396f0db060db9d8751167ea08f3a77a41a71cd39236fade4409394e57b377e8",
-                "sha256:69beffb048de19f7c18617b90e38cbddfac20077b1826c27c3fe2e3ef8ac5a43",
-                "sha256:7507439cd799295893b5602f438f8b6a0f483efb00720df1aa33a39102b41bcf",
-                "sha256:7aa40509dd9f75c256f0a7533d5e2ccef711dbbf0d91c13ac937d21d76d71656",
-                "sha256:7d69a3d980ecbf7238ab37b9027c87ad3b278bb3742a150fc33b5a8a9d990431",
-                "sha256:7dae2cf84a09329617b08731b95ad1fc98d50a9b40c2007e351438bd119a2f7a",
-                "sha256:7f36eacc70849d40ce86c85042ecfcbeab810691b1a3b08062ede32a2d6521ac",
-                "sha256:7f55a602d55e8f0feafde533c69dfd29bf0e54645ab0996b605613cda6894a85",
-                "sha256:8357aa727094798f1d831339ecfd8b3e388c01db6015a3cbd51790cb75e39994",
-                "sha256:84dc6bfeaeba98fe93fc837b12f9af4842694cdbde18083f150e80aec3de88f9",
-                "sha256:86b18420f00d5977bda477369ac85e04185ef94046a04ae0d85f5a807d1a8eb4",
-                "sha256:89f32d8450e15b0c11efdc81e2704d68c502c889d48415a50add9fa031144f75",
-                "sha256:8a1de8931cdad8cd12724e12a6167eef8cb478cc3ee5d2c9f4670c934f2975e1",
-                "sha256:8f106468062ac7ff03e3522a66cb7b36c662326d8eb7af1be0f30563740ff002",
-                "sha256:9a4ea87a0401c06b687db29e2ae836b2b58480ab118cb6eea8ac2ef45a4345f8",
-                "sha256:9ee1b019a4640bf39c0705ab65e934cfe6b89f1a8dc26f389fae3d7c62358d6f",
-                "sha256:a0d7c6d6fbca62508ea525abd869fca78ecf68cd3bcf6ae67ec478aa37cf39c0",
-                "sha256:a1417cb339a367a5dfd0e50193a1c0e87e31325547a0e7624ee4ff414c0b53b3",
-                "sha256:a35f1937b0560587d478fd2259a6d4f66cf511c9d28e90b52b183745eaa77d95",
-                "sha256:a4a35e83abfdac7095430e1c1476e0871e4b234e936f4a7a7631531b09a4f198",
-                "sha256:a7d1c8830a7bc10420ceb60a256d25ab5b032a6dad12a46af6ab2e470cee9124",
-                "sha256:a938d4d5b530f8ea988afb80817209eabc150c53b8c7af79d40080313a35e470",
-                "sha256:a9a2c377106fe01a57bad0f703653de286d56ee5285ed36c6953535cfa11f928",
-                "sha256:baf7546afd27be4f96f23307d7c295497fb512875167743b14a7457b95761294",
-                "sha256:bb21e2f35d6f09aa4a6df0c716f41e036cfcf05a98323b50294f93085ad775e9",
-                "sha256:bc62ba37bcb42e4146b853940b65a2de31c2962d2b6da9bc3ce28270d13b5c4e",
-                "sha256:be3ba736aabf856195199208ed37459408c932940cbccd2dc9f6ff2e800b0261",
-                "sha256:c03eb43d15c8af58159e7561076634d565530aaacaf48cf4e070c3501e88a372",
-                "sha256:c1349331fa743eed4042f9652200e60596f8beb957554acbcbb42aad4272c606",
-                "sha256:c3637cfce519560e2a2579d05eb81e912d109283b8ddc8de46f57ec20d273d92",
-                "sha256:c481cd1af2a77f58f495f7f87c2d715c6f1179d07c1ec927cca1f7977a2d99aa",
-                "sha256:c575f9499e5f540e034ff87bef894f031ae613a98b0d1d3afcc1f482527d5f1c",
-                "sha256:c604831daf2e7e5979ecd97a90cb8c4a7bae208ff45bc792e32eae09c3281afb",
-                "sha256:c759e1e0333664831d8d1d6b26cf59f23f3707758f696c71f506504b33130f81",
-                "sha256:c8a2743dd50629c0222f26c5f55975e45841d985b4b1c7a54b3f03b53de3427d",
-                "sha256:cbcac9263f500da94405cc9fc7e7a42a3ba6c2fe88b2cd7039737cba44c66889",
-                "sha256:cce1b7a680653e31ff2b252f19a39f1ded578a35a96c419ddb9632c62d2af7d8",
-                "sha256:cf96799b3e5e2e2f6dbca015f72b28e7ae415ce8147472f89a3704a035d6336d",
-                "sha256:d06ed18917dbc7a938c4231cbbec52a7e474be270b2ef9208abb4d5a34f5ceb9",
-                "sha256:d4ba5b4f1a0334dbe673f767f28775744e793fcb9ea57a1d72bc622c9f90e6b4",
-                "sha256:d7b8f25c9b0043cbaf77b8b895814e33e7a3c807a097377c07e1bd49946030d5",
-                "sha256:d86511ef8217822fb8716460aaa1ece31fe9e8a48900e541cb35acb7c35e9e2e",
-                "sha256:db8a9cbe965c7343feab2e2bf9a3771f303f8a7ca401dececb6ef28e06b3b18c",
-                "sha256:dbe92a8808cefb284e235b8f82933d7d2e24ff929fe5d53f1fd3ca55fced4b58",
-                "sha256:deb83cc9f639045e2febcc8d4306d4b83893af8d895f2ed70aa342a3430b534c",
-                "sha256:df9084e06efb3d59608a6a443faa9861828585579f0ae8e95f5a4dab70f1a00f",
-                "sha256:dfb89e92746e4a1e0d091cba73d6cc1e16b4094ebdbb14c2e96a80320feb1ad7",
-                "sha256:e13ddfe2ead9540e8773cae098f54c5206d6fcef64846a3e5042db47fc3a41ed",
-                "sha256:e4956384340eec7b526149ac126c8aa11d32441cb3ce77a690cb4821d0d0635c",
-                "sha256:e6eecd027b6ba5617ea6af3e12e20d578d8f4ad1bf51a9abe69c6fd4835ea532",
-                "sha256:eff9818b7671a55f1ce781398607e0d8c304cd430c0581fbe15b868a7a371c27",
-                "sha256:f0aea377b9dfc166c8fa05bb158c30ee3d53d73f0ed2fc05ba6c638d9563422f",
-                "sha256:f1fba193ab2f25849e24caa4570611aa2f80bc1c1ba791851523734b4ed69e43",
-                "sha256:f6db4f00d3baad615e99a865539391243d12b113fb628ebda1d7794ce02d5a10",
-                "sha256:f9405c02af86850e0a8a8ba777b7e7609e0d07bff46adc4f78892cc2d5456018",
-                "sha256:fb4445e3721720c5ca14c0650f35c263b3430e6e16df9d2504618df914b3fb99"
+                "sha256:01721da74558f2f64a9f162ee063df403ed656b7d84229268d8e4ae99cfba59c",
+                "sha256:07564178ecc203a84f63e72972691af6c0c82d2dc0c9da66ba711695276089ba",
+                "sha256:0f53253f4777cbccc426e669a2af875f26c95bd090d88593287b9a0a8ac7fa25",
+                "sha256:10f09c4f09757c2e2a707ad7304f5d69cb8fdf7cbfb644dbacfe5bbe8afe311b",
+                "sha256:124d0e880b66f9b0778613198e89984984fdd37a3030a9007e5f459a42dfa2d3",
+                "sha256:147a23cd96feb67606ac957744d8d25b013426cdc3c7164a4f99bd8253f649e3",
+                "sha256:153b8f8705970756226dfeeb7bb9637e0ad54a4d79b480b4c8244e34e16e1662",
+                "sha256:193cc97d44b1e6d2253ea94e30c6f94f994efb7166e2452af4df55825266e88b",
+                "sha256:1a957cdc2b26eeed4d8f1889a40c6023dd1bd94672dd0f5ce327314f2caaefd4",
+                "sha256:1c81414b706627f15e921e29ae2403aab52e33e36ed92ed989c602888d7c3b90",
+                "sha256:21238b19243a42f9a34a6d39e7580ceebc6da6d2f3cf729c1cff9023cb61a5f1",
+                "sha256:2bfe6b59f431f40fa545547616f4acf0c0c4b64518b1f951083e3bad06eb368b",
+                "sha256:314b556afd72eb21a6a10bd1f45ef252509f014f80207db59c97372103c88237",
+                "sha256:31c50da4a080166bc29403aa91f4c76e0889b4f24928d1b60508a37c1bf87f9a",
+                "sha256:3be53e9888e759c49ae35d747ff77a04ff82b894dd64601e0f3a5a159b406245",
+                "sha256:44b36ccb90aac5ea50be23c1a6e8f24fbfc78afabdef114af16c6e0a80981364",
+                "sha256:4cadaaa5c19ad23fc84559e90284f2eb003c36958ebb2c06f286b678f441285f",
+                "sha256:60c470a58c5b62b1b12a5f5458f8e2f2f67b94e198d03dc5352f854d9230c394",
+                "sha256:6673ab3fbf3135cc1a8c0f70d480db5b2378c3a70af8d602f73f76b8338bdf97",
+                "sha256:68e1e49a5675748233f7b05330f092582cd52f2850b4244939fd75ba640593ed",
+                "sha256:69d0180bca594e81cdb4a2af328bdb4046f59e10aaeef7619496fe64f2ec918c",
+                "sha256:6bd5888997ea3eae9830c6cc7964b61dcfbc50eb3a5a6ce56ad5f86d5579b11c",
+                "sha256:701d331060dae72bf3ebdb82924405d14136a69282ccb00c89fc69dee21340b4",
+                "sha256:70216ec4c248213ae95ea499b6314c385ce01a5946c448fb22f6c8395806e740",
+                "sha256:72f338f6aabd37d343bd9d1fdd3de921104d395766bcc5cdc4039e4c2dd97766",
+                "sha256:764fc15418d94bce5c2f8ebdbf66544f96f42efb1364b61e715e5b33281b388d",
+                "sha256:766acb5b1a19eae0f7467bcd3398748f110ea5309cdfc59faa5185dcc7fd4dca",
+                "sha256:76892bbce743eb9f90360b3626ea92f13d338010a1004b4488e79e555b339921",
+                "sha256:773467d25c293f8e981b092361dab5fd800e1ba318403b7959d35004c67faedc",
+                "sha256:80cbf0b043061451660099fff9001a7faacb2c9c983842b4819526e2f944dc6c",
+                "sha256:83168126ae2457d1a19b2af665cafa7ef78c2dcff192d7d7b5dad6b36c73ae24",
+                "sha256:83cc3c35aeeceb67143914db67f685206e1aa37ea837d872f4bc28d7f80917c9",
+                "sha256:8a86e8c2ac2ec87141e1c6cb00bdb18a4560f06e5f96769abcd1dda24dc0e764",
+                "sha256:8a9bc4dcfc2bda69ee88cdb7a89b03f2b8eca668519b704384a264dea2db4209",
+                "sha256:8c223aea52c359cc8fdee5bd3475532590755c269ec4d4fe581acd47a44e9952",
+                "sha256:8cbb868e88c4eee1c53364bb343d226a3c0e959e791e6828030cb78f46cfcbe3",
+                "sha256:902e2c9030cb042c49750bc70d72d830d42c64ea0df5ff8630c171e065c93dd7",
+                "sha256:a25c0eb2d610b20e276e684be61c337396813b636b69373c17314283cb1a3b14",
+                "sha256:a3efdf154844244e0dabe902cf1827fdced55fa5b144adec2a86e5ce50a99b97",
+                "sha256:a6bf01b9237f794fa3bdad5089474067d28be7e199b356a18d3f247a45775f26",
+                "sha256:a7eb5b06744b911b6668b427c8abc71b6d624e72d3dfffed00988fa1b4340f97",
+                "sha256:b0be613d926c5dbb0d3fc6b58e4f2be4979f80ae76fda6e47309f011b388fe0c",
+                "sha256:b211e161b6cc2790e0d640ad38e0429d06c944e5da23410f4dc61809dba25095",
+                "sha256:b537dd282de1b53d9ae7cf9f3df36420c8618390f2da92100391f3ba8f3c141a",
+                "sha256:c549bb519456ee230e92f415c5b4d962094caac0fdbcc4ed22b576f66169764e",
+                "sha256:c69ef5906dcd6ec565d4d887ba97ceb2a84f3b614307ee3b4780cb1ea40b1867",
+                "sha256:c8b4a782aac43948308087b962c9ecb030ba98886ce6dee3ad7aafe8c5e1ce80",
+                "sha256:cc7ebc37b03956a070260665079665eae69e5e96007694214f3a2107af96816a",
+                "sha256:ccfdc7722df445c49dc6b5d514c3544cad99b53189165f7546793933050ac7fb",
+                "sha256:d8bb745321716e7a11220a67c88212ecedde4021e1de4802e563baef9df921d2",
+                "sha256:d94f535df9f539615bc3dbbef185ded3b609373bb44ca1afffcabac70202678a",
+                "sha256:d98d2a8283c9928a9e5adf2f3c0181e095579e9732e1613aaa55d386e2bcb6c5",
+                "sha256:dc24737d24ce0de762bee9c2a884639819485f679bbac8ab5be9c161ef6f9b2c",
+                "sha256:e08fe1731f5429435b8dea1db9663f9ed1812915ff803fc9991c7c4841ed62ad",
+                "sha256:e09cdf5aad507c8faa30d97884cc42932ed3a9c2b7f22cc3ccc607bae03981b3",
+                "sha256:e152c26ffc30331e9d57591fc4c05453c209aa20ba299d1deb7173f7d1958c22",
+                "sha256:e1b8f5e2f9637492b0da4d51f78ecb17786e61d6c461ead8542c944750faf4f9",
+                "sha256:e39cacee70a98758f9b2da53ee175378f07c60113b1fa4fae40cbaee5583181e",
+                "sha256:e64442aba81ed4df1ca494b87bf818569a1280acaa73071c68014f7a884e83f1",
+                "sha256:e7dcb73f683c155885a3488646fcead3a895765fed16e93c9b80000bc69e96cb",
+                "sha256:ecdcb0d4e9b08b739035f57a09330efc6f464bd7f942b63897395d996ca6ebd5",
+                "sha256:ed90a9de4431cbfb2f3b2ef0c5fd356e61c85117b2be4db3eae28cb409f6e2d5",
+                "sha256:f1c23527f8e13f526fededbb96f2e7888f179fe27c51d41c2724f7059b75b2fa",
+                "sha256:f47d5f10922cf7f7dfcd1406bd0926cef6d866a75953c3745502dffd7ac197dd",
+                "sha256:fe0820d169635e41c14a5d21514282e0b93347878666ec9d5d3bf0eed0649948",
+                "sha256:ff66014687598823b6b23751884b4aa67eb934445406d95894dfc60cb7bfcc18"
             ],
-            "markers": "python_full_version >= '3.6.2'",
-            "version": "==4.1.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==4.2.0"
         },
         "python-jose": {
             "hashes": [
@@ -303,11 +294,11 @@
         },
         "rsa": {
             "hashes": [
-                "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17",
-                "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"
+                "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
+                "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
             ],
             "markers": "python_version >= '3.6' and python_version < '4'",
-            "version": "==4.8"
+            "version": "==4.9"
         },
         "six": {
             "hashes": [
@@ -693,16 +684,16 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
-                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
+                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.10"
+            "version": "==1.26.11"
         }
     }
 }

--- a/backend/README.md
+++ b/backend/README.md
@@ -78,6 +78,10 @@ pipenv run -- app --port=<int>
 
 > :bulb: Note: The frontend uses port 3000 for hosting.
 
+#### Testing in API Client
+
+If you want to send requests to the Hapley API from an API tool such as **Postman**, you'll need to mock the cookies traditionally attached to requests via CorpSecure. For example, if you send a `GET` request to `http://localhost:8000/api/v1`, the request headers must contain a key `cookie` with a value of `auth_user=<mongo-username>; auth_token=<jwt-token>` where `jwt-token` is the token generated via a request to `/api/v1/sample-token` and `mongo-username` equals the `username` query parameter passed to `/api/v1/sample-token`.
+
 ### Running in a Docker Container
 
 If you'd like to develop locally using Docker, ensure that you have Docker

--- a/backend/api/core/middleware/authorization.py
+++ b/backend/api/core/middleware/authorization.py
@@ -33,12 +33,8 @@ class Authorization(BaseHTTPMiddleware):
 
         try:
             # For local development, JWT comes from env file not Authorization header
-            auth_headers = request.headers.get("Authorization")
-            print(auth_headers)
-            print(request.headers)
-            token = (auth_headers and self.parse_header(auth_headers)) or getenv(
-                "JWT_TOKEN"
-            )
+            cookies = request.cookies
+            token = (cookies and cookies["auth_token"]) or getenv("JWT_TOKEN")
             token_data: TokenData = parse_jwt(token)
 
             if bool(self.AUTHORIZED_OKTA_GROUPS & set(token_data.groups)):
@@ -59,9 +55,6 @@ class Authorization(BaseHTTPMiddleware):
                 },
             )
         return response
-
-    def parse_header(self, auth_headers: str):
-        return auth_headers.split(" ")[1]
 
     @classmethod
     def build_sample_token(

--- a/backend/api/core/middleware/authorization.py
+++ b/backend/api/core/middleware/authorization.py
@@ -34,6 +34,8 @@ class Authorization(BaseHTTPMiddleware):
         try:
             # For local development, JWT comes from env file not Authorization header
             auth_headers = request.headers.get("Authorization")
+            print(auth_headers)
+            print(request.headers)
             token = (auth_headers and self.parse_header(auth_headers)) or getenv(
                 "JWT_TOKEN"
             )

--- a/backend/api/tests/base.py
+++ b/backend/api/tests/base.py
@@ -14,7 +14,7 @@ class FastApiTest(TestClient):
             token = Authorization.build_sample_token(
                 email="foo@gmail.com", username="foo"
             )
-            self.headers = {"Authorization": "Bearer " + token}
+            self.headers = {"cookie": "auth_user=foo; auth_token=" + token}
 
     # TestClient uses urljoin, which requires a trailing slash on base_url
     # and no leading slash on the second arg. https://stackoverflow.com/questions/69166262/fastapi-adding-route-prefix-to-testclient

--- a/backend/api/tests/unit/middleware/test_authorization.py
+++ b/backend/api/tests/unit/middleware/test_authorization.py
@@ -24,7 +24,7 @@ def test_sample_jwt():
         "/sample-token?email=foo@gmail.com&username=foo"
     )
     unauthorized_client.headers = {
-        "Authorization": "Bearer " + token_response.json()["token"]
+        "cookie": "auth_user=foo.bar; auth_token= " + token_response.json()["token"]
     }
 
     response = unauthorized_client.get("/")
@@ -36,7 +36,9 @@ def test_sample_jwt():
 
 
 def test_invalid_jwt():
-    unauthorized_client.headers = {"Authorization": "Bearer " + "invalid_token"}
+    unauthorized_client.headers = {
+        "cookie": "auth_user=foo.bar; auth_token=invalid_token"
+    }
 
     response = unauthorized_client.get("/")
     assert response.status_code == 401
@@ -51,7 +53,9 @@ def test_invalid_okta_group():
     unauthorized_jwt = Authorization.build_sample_token(
         email="foo@mongodb.com", username="foo", is_authorized=False
     )
-    unauthorized_client.headers = {"Authorization": "Bearer " + unauthorized_jwt}
+    unauthorized_client.headers = {
+        "cookie": "auth_user=foo.bar; auth_token=" + unauthorized_jwt
+    }
 
     response = unauthorized_client.get("/")
     assert response.status_code == 401


### PR DESCRIPTION
## Ticket

[DOP-3149](https://jira.mongodb.org/browse/DOP-3149)

## Notes

#8 failed to deploy to staging via Drone pipelines due to a broken backend `Dockerfile`. The `Dockerfile` did not reflect the latest changes to the project structure. This PR ensures that the backend image can build successfully.

I've also added the `dnspython`, which PyMongo needs in order to parse connection strings for an Atlas database.

This PR also fixes an issue with user authorization. We previously assumed that authorization tokens got passed to the backend via the `Authorization` request header (by the CorpSecure authentication proxy). However, the tokens get passed as a cookie with cookie name of `auth_token`. The middleware now understands how to parse the auth_token to authorize and identify a user.

I've also added a brief section to the backend README on how to send authorized requests to the backend via a tool such as Postman.